### PR TITLE
fix path for go mod inclusion

### DIFF
--- a/burst.go
+++ b/burst.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/momokatte/go-backoff"
-	vrl "github.com/youtube/vitess/go/ratelimiter"
+	vrl "vitess.io/vitess/go/ratelimiter"
 )
 
 /*


### PR DESCRIPTION
This fixes the error

```
	github.com/youtube/vitess/go/ratelimiter: github.com/youtube/vitess@v0.7.0: parsing go.mod:
	module declares its path as: vitess.io/vitess
	        but was required as: github.com/youtube/vitess
```

when this project is included via go modules
